### PR TITLE
Update manifest for cflinuxfs3

### DIFF
--- a/web-ui/manifest.yml
+++ b/web-ui/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: web-ui
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.35
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.41
   memory: 128M
   instances: 1
-  stack: cflinuxfs2
+  stack: cflinuxfs3


### PR DESCRIPTION
Updates the stack and ruby buildpack (which as a consequence must also be bumped). I've tested locally (both with this buildpack and the staticfile buildpack also used with this app in the CFCD course) and it seems to work fine.

Necessary because cflinuxfs2 is deprecated as of April 2019. 